### PR TITLE
Make configure "just work"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -21,13 +21,5 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get install -y xorg
 
-      # consolidate macOS and Ubuntu builds after fixing ./configure on macOS
-      - name: Build on macOS
-        if: runner.os == 'macOS'
-        run: |
-          ./configure --x-includes=/opt/X11/include --x-libraries=/opt/X11/lib
-          make
-
-      - name: Build on Ubuntu
-        if: runner.os == 'Linux'
+      - name: Build
         run: ./configure && make

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This project takes the most recent version of xplot (v0.90.7.1 from Sept. 19,
 2003!), and ports it forward so xplot may be built on macOS. The original source
-of xplot was taken from [xplot.org](http://xplot.org).
+of xplot was taken from [xplot.org](http://xplot.org). Only the most minimal
+changes required to build and run xplot on macOS have been made. No substantial
+features have been added, nor are any features planned.
 
 xplot's README is [README](README).
 
@@ -12,25 +14,19 @@ X11 is required, and can be installed via:
 - [Homebrew](https://brew.sh) with `brew install xquartz`, or
 - direct download from [xquartz.org](https://www.xquartz.org).
 
-Either method should have installed X11 at `/opt/X11`. If not, create a symbolic
-link to that path, or modify the paths in the parameters to `./configure`
-described [below](#macOS).
-
 
 ## Installation
-### macOS
-At the moment, the configure script is unable to automatically detect whether
-X11 is installed, so we manually provide it's location. So, xplot is built by
-running:
+Simply run
 ```shell
-./configure --x-includes=/opt/X11/include --x-libraries=/opt/X11/lib
-make
+./configure && make
 ```
-
-### All other operating systems
-If `./configure && make` do not suffice, run `git clean -xf`, and then try the
-instructions for [macOS above](#macOS). If you compiled xplot on another system,
-I'd love to hear how you did it. Please open an issue to let me know.
+to build xplot. Then, run xplot like so
+```shell
+./xplot /path/to/xplot/file
+```
+This has been tested on macOS 11.2 and Ubuntu 16.04. I'd love to hear if you
+successfully build and run this project on another system. Please open an issue
+to let me know.
 
 
 ## Contributing

--- a/configure
+++ b/configure
@@ -954,7 +954,7 @@ EOF
     # GNU make sometimes prints "make[1]: Entering...", which would confuse us.
     eval `${MAKE-make} acfindx 2>/dev/null | grep -v make`
     # Open Windows xmkmf reportedly sets LIBDIR instead of USRLIBDIR.
-    for ac_extension in a so sl; do
+    for ac_extension in a so sl dylib; do
       if test ! -f $ac_im_usrlibdir/libX11.$ac_extension &&
         test -f $ac_im_libdir/libX11.$ac_extension; then
         ac_im_usrlibdir=$ac_im_libdir; break
@@ -1112,7 +1112,7 @@ for ac_dir in `echo "$ac_x_includes" | sed s/include/lib/` \
     /usr/openwin/share/lib \
     ; \
 do
-  for ac_extension in a so sl; do
+  for ac_extension in a so sl dylib; do
     if test -r $ac_dir/lib${x_direct_test_library}.$ac_extension; then
       ac_x_libraries=$ac_dir
       break 2


### PR DESCRIPTION
This fixes the problem of ./configure not "just working" on macOS. I
wonder why macOS deviated from the .a, .so, and .sl extensions? My guess
is one of these was used for shared libraries in the old days, and OS X
switched to dylibs, but that's just speculation.

Resolves #1.