### PR TITLE
Fix install target and add uninstall target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 
 bindir = $(exec_prefix)/bin
-mandir = $(exec_prefix)/man/man1
+mandir = $(exec_prefix)/share/man/man1
 
 CFILES= xplot.c version_string.c coord.c unsigned.c signed.c timeval.c double.c dtime.c
 OFILES= xplot.o version_string.o coord.o unsigned.o signed.o timeval.o double.o dtime.o

--- a/Makefile.in
+++ b/Makefile.in
@@ -78,6 +78,10 @@ install: all
 clean:
 	rm -f ${PROG} ${PROG}.old *.o version_string.c
 
+uninstall:
+	cd $(bindir); $(RM) xplot tcpdump2xplot
+	cd $(mandir); $(RM) $(MANFILES)
+
 # (note: "mkdep" below denotes the BSD 4.3+tahoe /usr/bin/mkdep )
 depend:
 	mkdep ${INCLUDES} ${CFILES}

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This project takes the most recent version of xplot (v0.90.7.1 from Sept. 19,
 2003!), and ports it forward so xplot may be built on macOS. The original source
 of xplot was taken from [xplot.org](http://xplot.org). Only the most minimal
-changes required to build and run xplot on macOS have been made. No substantial
-features have been added, nor are any features planned.
+changes required to build, install, run, and uninstall xplot on macOS have been
+made. No substantial features have been added, nor are any features planned.
 
 xplot's README is [README](README).
 
@@ -18,15 +18,28 @@ X11 is required, and can be installed via:
 ## Installation
 Simply run
 ```shell
-./configure && make
+./configure
+make
+make install
 ```
-to build xplot. Then, run xplot like so
+to build and install xplot. Then, run xplot like so
 ```shell
-./xplot /path/to/xplot/file
+xplot /path/to/xplot/file
 ```
-This has been tested on macOS 11.2 and Ubuntu 16.04. I'd love to hear if you
+The following man pages are also installed: `xplot(1)` and `tcpdump2xplot(1)`.
+
+
+## Support
+This project has been tested on macOS Big Sur 11.2. I'd love to hear if you
 successfully build and run this project on another system. Please open an issue
 to let me know.
+
+
+## Uninstallation
+If xplot was installed with `make install`, then it may be uninstalled using
+```shell
+make uninstall
+```
 
 
 ## Contributing


### PR DESCRIPTION
This PR:
- fixes the install target for macOS. In particular, the man directory was changed.
- adds an uninstall target to remove installed executables and man pages.
- updates documentation.